### PR TITLE
fixes: prod should only be deployable from main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,6 @@ aliases:
     branches:
       only:
         - main
-  - &only-main-releases
-    tags:
-      only: /v[0-9]+(\.[0-9]+)/
-    branches:
-      only: main
   - &only-untagged
     tags:
       ignore: /.*/
@@ -217,43 +212,27 @@ workflows:
           filters: *only-main
           requires:
             - checkout-revision-setup
-      - approve-deploy-qa:
-          type: approval
+      - qa-ebs-deploy:
           filters: *only-main
           requires:
             - test
             - test-license
-      - qa-ebs-deploy:
-          filters: *only-main
-          requires:
-            - approve-deploy-qa
       - videos-sync-dev2qa:
           filters: *only-main
           requires:
-            - approve-deploy-qa
-  test-and-deploy-release:
-    jobs:
-      - checkout-revision-setup:
-          filters: *only-main-releases
-      - test-license:
-          filters: *only-main-releases
-          requires:
-            - checkout-revision-setup
-      - test:
-          filters: *only-main-releases
-          requires:
-            - checkout-revision-setup
+            - test
+            - test-license
       - approve-deploy-prod:
           type: approval
-          filters: *only-main-releases
+          filters: *only-main
           requires:
             - test
             - test-license
       - prod-ebs-deploy:
-          filters: *only-main-releases
+          filters: *only-main
           requires:
             - approve-deploy-prod
       - videos-sync-qa2prod:
-          filters: *only-main-releases
+          filters: *only-main
           requires:
             - approve-deploy-prod


### PR DESCRIPTION
prior config had a filter for prod deployment that specified

  branches:
    only:
      - main
  tags:
    only:
      - (regex for a version tag)

...unfortunately, seems like multiple filters work
as a logical OR rather than AND.

It's important to NOT let anyone who can create a tag
have the ability to publish to production,
so changing the rule to require just main branch
for prod publishes.

Will be up to publishers to remember to create tags :/